### PR TITLE
[setup.py] Fix `python_requires` specifier to conform with PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author=module.__author__,
     author_email=module.team_email,
     provides=["aiocarbon"],
-    python_requires=">3.5.*, <4",
+    python_requires=">=3.5, <4",
     keywords=["aio", "python", "asyncio", "carbon", "graphite", "client"],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi.

Currently, `python_requires` is specified as `>3.5.*, <4`, but this value does not conform to [PEP 440](https://peps.python.org/pep-0440/) version specification: `.*`, as I understand, is only allowed for [Version matching](https://peps.python.org/pep-0440/#version-matching) and [Version exclusion](https://peps.python.org/pep-0440/#version-exclusion) (`==` and `!=` operators).

Because of it, installation of `aiocarbon` using modern versions of `pip` does not work:
```bash
$ pip --version
pip 23.2.1 from .../python3.11/site-packages/pip (python 3.11)

$ git rev-parse HEAD
0dbbe0c63fd6ed6c8f10ef1a64483022488bd632

$ grep python_requires setup.py
    python_requires=">3.5.*, <4",

$ pip install -e .
...
      error in aiocarbon setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>3.5.*'
...
```

I changed it to `>=3.5, <4`: with this change, `pip install` does work.